### PR TITLE
Fix TestDataUtil tag parsing

### DIFF
--- a/src/test/java/de/iske/kistogramm/controller/TestDataUtil.java
+++ b/src/test/java/de/iske/kistogramm/controller/TestDataUtil.java
@@ -90,7 +90,7 @@ public class TestDataUtil {
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
 
-        var createdTag = objectMapper.readValue(response, Storage.class);
+        var createdTag = objectMapper.readValue(response, Tag.class);
 
         return createdTag.getId();
     }


### PR DESCRIPTION
## Summary
- correct DTO type for tag creation utility

## Testing
- `./mvnw -q test` *(fails: unable to download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68444ae6a300832eb142d7b992c2ac33