### PR TITLE
Add image type handling

### DIFF
--- a/src/main/java/de/iske/kistogramm/controller/ImageController.java
+++ b/src/main/java/de/iske/kistogramm/controller/ImageController.java
@@ -61,6 +61,7 @@ public class ImageController {
     public ResponseEntity<Image> uploadImage(@RequestParam("file") MultipartFile file) throws IOException {
         Image image = new Image();
         image.setData(file.getBytes());
+        image.setType(file.getContentType());
         image.setDateAdded(LocalDateTime.now());
         image.setDateModified(LocalDateTime.now());
         return ResponseEntity.ok(imageService.createImage(image));

--- a/src/main/java/de/iske/kistogramm/dto/Image.java
+++ b/src/main/java/de/iske/kistogramm/dto/Image.java
@@ -13,6 +13,7 @@ public class Image {
     private UUID uuid;
     private byte[] data;
     private String description;
+    private String type;
     private LocalDateTime dateAdded;
     private LocalDateTime dateModified;
 
@@ -46,6 +47,14 @@ public class Image {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 
     public LocalDateTime getDateAdded() {
@@ -87,6 +96,7 @@ public class Image {
                 .add("id", id)
                 .add("uuid", uuid)
                 .add("description", description)
+                .add("type", type)
                 .add("data.length", data != null ? data.length : 0)
                 .add("dateAdded", dateAdded)
                 .add("dateModified", dateModified)

--- a/src/main/java/de/iske/kistogramm/dto/export/ExportImage.java
+++ b/src/main/java/de/iske/kistogramm/dto/export/ExportImage.java
@@ -7,6 +7,7 @@ public class ExportImage {
 
     private UUID uuid;
     private String description;
+    private String type;
     private LocalDateTime dateAdded;
     private LocalDateTime dateModified;
 
@@ -24,6 +25,14 @@ public class ExportImage {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 
     public LocalDateTime getDateAdded() {

--- a/src/main/java/de/iske/kistogramm/model/ImageEntity.java
+++ b/src/main/java/de/iske/kistogramm/model/ImageEntity.java
@@ -19,6 +19,9 @@ public class ImageEntity {
 
     private String description;
 
+    @Column(name = "type")
+    private String type;
+
     @Column(name = "data", nullable = false, columnDefinition = "BYTEA")
     private byte[] data;
 
@@ -55,6 +58,14 @@ public class ImageEntity {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 
     public void setUuid(UUID uuid) {
@@ -146,6 +157,7 @@ public class ImageEntity {
                 .add("id", id)
                 .add("uuid", uuid)
                 .add("description", description)
+                .add("type", type)
                 .add("belongsTo", resolveOwner())
                 .add("data.length", data != null ? data.length : 0)
                 .add("dateAdded", dateAdded)

--- a/src/main/java/de/iske/kistogramm/service/ItemService.java
+++ b/src/main/java/de/iske/kistogramm/service/ItemService.java
@@ -247,6 +247,7 @@ public class ItemService {
             try {
                 ImageEntity image = new ImageEntity();
                 image.setData(file.getBytes());
+                image.setType(file.getContentType());
                 image.setDateAdded(LocalDateTime.now());
                 image.setDateModified(LocalDateTime.now());
                 image.setItem(item);

--- a/src/main/java/de/iske/kistogramm/service/RoomService.java
+++ b/src/main/java/de/iske/kistogramm/service/RoomService.java
@@ -105,6 +105,7 @@ public class RoomService {
         try {
             ImageEntity image = new ImageEntity();
             image.setData(file.getBytes());
+            image.setType(file.getContentType());
             image.setDateAdded(LocalDateTime.now());
             image.setDateModified(LocalDateTime.now());
             imageRepository.save(image);

--- a/src/main/java/de/iske/kistogramm/service/StorageService.java
+++ b/src/main/java/de/iske/kistogramm/service/StorageService.java
@@ -147,6 +147,7 @@ public class StorageService {
             try {
                 ImageEntity image = new ImageEntity();
                 image.setData(file.getBytes());
+                image.setType(file.getContentType());
                 image.setDateAdded(LocalDateTime.now());
                 image.setDateModified(LocalDateTime.now());
                 image.setStorage(storage);

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -68,6 +68,7 @@ CREATE TABLE IF NOT EXISTS images (
     id SERIAL PRIMARY KEY,
     uuid UUID NOT NULL UNIQUE,
     description TEXT,
+    type VARCHAR(255),
     data BYTEA NOT NULL,
     date_added TIMESTAMP,
     date_modified TIMESTAMP,


### PR DESCRIPTION
## Summary
- track uploaded image type in the database
- expose the image type through DTOs
- include image type in export data
- store image type when uploading images
- integrate the image type column into the initial Flyway migration

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68445bca6244832eb528620b21e47fc3