### PR TITLE
Implement archive import with overwrite

### DIFF
--- a/src/main/java/de/iske/kistogramm/dto/ImportResult.java
+++ b/src/main/java/de/iske/kistogramm/dto/ImportResult.java
@@ -23,6 +23,8 @@ public class ImportResult {
   private int updatedRoomCount;
   private int importedTagCount;
   private int updatedTagCount;
+  private int importedCategoryAttributeTemplateCount;
+  private int updatedCategoryAttributeTemplateCount;
 
   private List<String> errors;
   private List<String> warnings;
@@ -161,6 +163,22 @@ public class ImportResult {
 
   public void setUpdatedTagCount(int updatedTagCount) {
     this.updatedTagCount = updatedTagCount;
+  }
+
+  public int getImportedCategoryAttributeTemplateCount() {
+    return importedCategoryAttributeTemplateCount;
+  }
+
+  public void setImportedCategoryAttributeTemplateCount(int importedCategoryAttributeTemplateCount) {
+    this.importedCategoryAttributeTemplateCount = importedCategoryAttributeTemplateCount;
+  }
+
+  public int getUpdatedCategoryAttributeTemplateCount() {
+    return updatedCategoryAttributeTemplateCount;
+  }
+
+  public void setUpdatedCategoryAttributeTemplateCount(int updatedCategoryAttributeTemplateCount) {
+    this.updatedCategoryAttributeTemplateCount = updatedCategoryAttributeTemplateCount;
   }
 
   public List<String> getErrors() {

--- a/src/main/java/de/iske/kistogramm/repository/CategoryAttributeTemplateRepository.java
+++ b/src/main/java/de/iske/kistogramm/repository/CategoryAttributeTemplateRepository.java
@@ -5,10 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @Repository
 public interface CategoryAttributeTemplateRepository extends JpaRepository<CategoryAttributeTemplateEntity, Integer> {
     List<CategoryAttributeTemplateEntity> findByCategoryId(Integer categoryId);
 
     boolean existsByCategoryIdAndAttributeName(Integer categoryId, String attributeName);
+
+    Optional<CategoryAttributeTemplateEntity> findByUuid(UUID uuid);
 }

--- a/src/main/java/de/iske/kistogramm/service/ImportService.java
+++ b/src/main/java/de/iske/kistogramm/service/ImportService.java
@@ -49,20 +49,31 @@ public class ImportService {
 
   public ImportResult importArchive(MultipartFile file, boolean overwrite, boolean failOnError) throws IOException {
     ImportResult importResult = new ImportResult();
+    importResult.setOverwriteMode(overwrite);
+    importResult.setSuccess(false);
+    importResult.setErrors(new ArrayList<>());
+    importResult.setWarnings(new ArrayList<>());
 
     Map<String, byte[]> files = extractFiles(file);
     ExportResult result = parseExportResult(files.get("data.json"));
 
-    Map<UUID, ImageEntity> images = importImages(result.getImages(), files);
-    Map<UUID, RoomEntity> rooms = importRooms(result.getRooms(), images);
-    Map<UUID, StorageEntity> storages = importStorages(result.getStorages(), rooms, images);
-    Map<UUID, CategoryEntity> categories = importCategories(result.getCategories());
-    Map<UUID, TagEntity> tags = importTags(result.getTags());
-    importCategoryAttributeTemplates(result.getCategoryAttributeTemplates(), categories);
-    Map<UUID, ItemEntity> items = importItems(result.getItems(), categories, storages, tags, images);
-    linkRelatedItems(result.getItems(), items);
+    try {
+      Map<UUID, ImageEntity> images = importImages(result.getImages(), files, overwrite, failOnError, importResult);
+      Map<UUID, RoomEntity> rooms = importRooms(result.getRooms(), images, overwrite, failOnError, importResult);
+      Map<UUID, StorageEntity> storages = importStorages(result.getStorages(), rooms, images, overwrite, failOnError, importResult);
+      Map<UUID, CategoryEntity> categories = importCategories(result.getCategories(), overwrite, failOnError, importResult);
+      Map<UUID, TagEntity> tags = importTags(result.getTags(), overwrite, failOnError, importResult);
+      importCategoryAttributeTemplates(result.getCategoryAttributeTemplates(), categories);
+      Map<UUID, ItemEntity> items = importItems(result.getItems(), categories, storages, tags, images, overwrite, failOnError, importResult);
+      linkRelatedItems(result.getItems(), items);
+    } catch (RuntimeException ex) {
+      if (failOnError) {
+        importResult.setSuccess(false);
+        return importResult;
+      }
+    }
 
-
+    importResult.setSuccess(importResult.getErrors().isEmpty());
     return importResult;
   }
 
@@ -86,118 +97,245 @@ public class ImportService {
     return objectMapper.readValue(jsonBytes, ExportResult.class);
   }
 
-  private Map<UUID, ImageEntity> importImages(List<ExportImage> exportImages, Map<String, byte[]> files) {
+  private Map<UUID, ImageEntity> importImages(List<ExportImage> exportImages,
+                                             Map<String, byte[]> files,
+                                             boolean overwrite,
+                                             boolean failOnError,
+                                             ImportResult result) {
     Map<UUID, ImageEntity> map = new HashMap<>();
     if (exportImages == null) {
       return map;
     }
     for (ExportImage exp : exportImages) {
-      if (imageRepository.findByUuid(exp.getUuid()).isPresent()) {
-        continue;
+      try {
+        Optional<ImageEntity> existing = imageRepository.findByUuid(exp.getUuid());
+        ImageEntity entity;
+        if (existing.isPresent()) {
+          if (!overwrite) {
+            result.setSkippedTotalCount(result.getSkippedTotalCount() + 1);
+            map.put(exp.getUuid(), existing.get());
+            continue;
+          }
+          entity = existing.get();
+          result.setUpdatedTotalCount(result.getUpdatedTotalCount() + 1);
+        } else {
+          entity = new ImageEntity();
+          result.setImportedImageCount(result.getImportedImageCount() + 1);
+          result.setImportedTotalCount(result.getImportedTotalCount() + 1);
+        }
+        entity.setUuid(exp.getUuid());
+        entity.setDescription(exp.getDescription());
+        entity.setDateAdded(exp.getDateAdded() != null ? exp.getDateAdded() : LocalDateTime.now());
+        entity.setDateModified(exp.getDateModified() != null ? exp.getDateModified() : LocalDateTime.now());
+        byte[] data = files.get("images/" + exp.getUuid());
+        entity.setData(data != null ? data : new byte[0]);
+        map.put(exp.getUuid(), imageRepository.save(entity));
+      } catch (Exception e) {
+        result.getErrors().add("Failed to import image " + exp.getUuid());
+        result.setFailedTotalCount(result.getFailedTotalCount() + 1);
+        if (failOnError) {
+          throw new RuntimeException(e);
+        }
       }
-      ImageEntity entity = new ImageEntity();
-      entity.setUuid(exp.getUuid());
-      entity.setDescription(exp.getDescription());
-      entity.setDateAdded(exp.getDateAdded() != null ? exp.getDateAdded() : LocalDateTime.now());
-      entity.setDateModified(exp.getDateModified() != null ? exp.getDateModified() : LocalDateTime.now());
-      byte[] data = files.get("images/" + exp.getUuid());
-      if (data != null) {
-        entity.setData(data);
-      } else {
-        entity.setData(new byte[0]);
-      }
-      map.put(exp.getUuid(), imageRepository.save(entity));
     }
     return map;
   }
 
-  private Map<UUID, RoomEntity> importRooms(List<ExportRoom> exportRooms, Map<UUID, ImageEntity> images) {
+  private Map<UUID, RoomEntity> importRooms(List<ExportRoom> exportRooms,
+                                            Map<UUID, ImageEntity> images,
+                                            boolean overwrite,
+                                            boolean failOnError,
+                                            ImportResult result) {
     Map<UUID, RoomEntity> map = new HashMap<>();
     if (exportRooms == null) {
       return map;
     }
     for (ExportRoom exp : exportRooms) {
-      RoomEntity entity = roomRepository.findByUuid(exp.getUuid()).orElseGet(RoomEntity::new);
-      entity.setUuid(exp.getUuid());
-      entity.setName(exp.getName());
-      entity.setDescription(exp.getDescription());
-      entity.setDateAdded(exp.getDateAdded() != null ? exp.getDateAdded() : LocalDateTime.now());
-      entity.setDateModified(exp.getDateModified() != null ? exp.getDateModified() : LocalDateTime.now());
-      if (exp.getImage() != null) {
-        ImageEntity img = images.get(exp.getImage());
-        if (img != null) {
-          entity.setImage(img);
-          img.setRoom(entity);
+      try {
+        Optional<RoomEntity> existing = roomRepository.findByUuid(exp.getUuid());
+        RoomEntity entity;
+        if (existing.isPresent()) {
+          if (!overwrite) {
+            result.setSkippedTotalCount(result.getSkippedTotalCount() + 1);
+            map.put(exp.getUuid(), existing.get());
+            continue;
+          }
+          entity = existing.get();
+          result.setUpdatedRoomCount(result.getUpdatedRoomCount() + 1);
+          result.setUpdatedTotalCount(result.getUpdatedTotalCount() + 1);
+        } else {
+          entity = new RoomEntity();
+          result.setImportedRoomCount(result.getImportedRoomCount() + 1);
+          result.setImportedTotalCount(result.getImportedTotalCount() + 1);
+        }
+        entity.setUuid(exp.getUuid());
+        entity.setName(exp.getName());
+        entity.setDescription(exp.getDescription());
+        entity.setDateAdded(exp.getDateAdded() != null ? exp.getDateAdded() : LocalDateTime.now());
+        entity.setDateModified(exp.getDateModified() != null ? exp.getDateModified() : LocalDateTime.now());
+        if (exp.getImage() != null) {
+          ImageEntity img = images.get(exp.getImage());
+          if (img != null) {
+            entity.setImage(img);
+            img.setRoom(entity);
+          }
+        }
+        map.put(exp.getUuid(), roomRepository.save(entity));
+      } catch (Exception e) {
+        result.getErrors().add("Failed to import room " + exp.getUuid());
+        result.setFailedTotalCount(result.getFailedTotalCount() + 1);
+        if (failOnError) {
+          throw new RuntimeException(e);
         }
       }
-      map.put(exp.getUuid(), roomRepository.save(entity));
     }
     return map;
   }
 
   private Map<UUID, StorageEntity> importStorages(List<ExportStorage> exportStorages,
                                                   Map<UUID, RoomEntity> rooms,
-                                                  Map<UUID, ImageEntity> images) {
+                                                  Map<UUID, ImageEntity> images,
+                                                  boolean overwrite,
+                                                  boolean failOnError,
+                                                  ImportResult result) {
     Map<UUID, StorageEntity> map = new HashMap<>();
     if (exportStorages == null) {
       return map;
     }
     for (ExportStorage exp : exportStorages) {
-      StorageEntity entity = storageRepository.findByUuid(exp.getUuid()).orElseGet(StorageEntity::new);
-      entity.setUuid(exp.getUuid());
-      entity.setName(exp.getName());
-      entity.setDescription(exp.getDescription());
-      entity.setDateAdded(exp.getDateAdded() != null ? exp.getDateAdded() : LocalDateTime.now());
-      entity.setDateModified(exp.getDateModified() != null ? exp.getDateModified() : LocalDateTime.now());
-      if (exp.getRoom() != null) {
-        entity.setRoom(rooms.get(exp.getRoom()));
-      }
-      if (exp.getParentStorage() != null) {
-        entity.setParentStorage(storageRepository.findByUuid(exp.getParentStorage()).orElse(null));
-      }
-      StorageEntity saved = storageRepository.save(entity);
-      map.put(exp.getUuid(), saved);
-      if (exp.getImages() != null) {
-        for (UUID imgUuid : exp.getImages()) {
-          ImageEntity img = images.get(imgUuid);
-          if (img != null) {
-            img.setStorage(saved);
-            imageRepository.save(img);
+      try {
+        Optional<StorageEntity> existing = storageRepository.findByUuid(exp.getUuid());
+        StorageEntity entity;
+        if (existing.isPresent()) {
+          if (!overwrite) {
+            result.setSkippedTotalCount(result.getSkippedTotalCount() + 1);
+            map.put(exp.getUuid(), existing.get());
+            continue;
           }
+          entity = existing.get();
+          result.setUpdatedStorageCount(result.getUpdatedStorageCount() + 1);
+          result.setUpdatedTotalCount(result.getUpdatedTotalCount() + 1);
+        } else {
+          entity = new StorageEntity();
+          result.setImportedStorageCount(result.getImportedStorageCount() + 1);
+          result.setImportedTotalCount(result.getImportedTotalCount() + 1);
+        }
+
+        entity.setUuid(exp.getUuid());
+        entity.setName(exp.getName());
+        entity.setDescription(exp.getDescription());
+        entity.setDateAdded(exp.getDateAdded() != null ? exp.getDateAdded() : LocalDateTime.now());
+        entity.setDateModified(exp.getDateModified() != null ? exp.getDateModified() : LocalDateTime.now());
+        if (exp.getRoom() != null) {
+          entity.setRoom(rooms.get(exp.getRoom()));
+        }
+        if (exp.getParentStorage() != null) {
+          entity.setParentStorage(storageRepository.findByUuid(exp.getParentStorage()).orElse(null));
+        }
+        StorageEntity saved = storageRepository.save(entity);
+        map.put(exp.getUuid(), saved);
+        if (exp.getImages() != null) {
+          for (UUID imgUuid : exp.getImages()) {
+            ImageEntity img = images.get(imgUuid);
+            if (img != null) {
+              img.setStorage(saved);
+              imageRepository.save(img);
+            }
+          }
+        }
+      } catch (Exception e) {
+        result.getErrors().add("Failed to import storage " + exp.getUuid());
+        result.setFailedTotalCount(result.getFailedTotalCount() + 1);
+        if (failOnError) {
+          throw new RuntimeException(e);
         }
       }
     }
     return map;
   }
 
-  private Map<UUID, CategoryEntity> importCategories(List<ExportCategory> exportCategories) {
+  private Map<UUID, CategoryEntity> importCategories(List<ExportCategory> exportCategories,
+                                                     boolean overwrite,
+                                                     boolean failOnError,
+                                                     ImportResult result) {
     Map<UUID, CategoryEntity> map = new HashMap<>();
     if (exportCategories == null) {
       return map;
     }
     for (ExportCategory exp : exportCategories) {
-      CategoryEntity entity = categoryRepository.findByUuid(exp.getUuid()).orElseGet(CategoryEntity::new);
-      entity.setUuid(exp.getUuid());
-      entity.setName(exp.getName());
-      entity.setDateAdded(exp.getDateAdded() != null ? exp.getDateAdded() : LocalDateTime.now());
-      entity.setDateModified(exp.getDateModified() != null ? exp.getDateModified() : LocalDateTime.now());
-      map.put(exp.getUuid(), categoryRepository.save(entity));
+      try {
+        Optional<CategoryEntity> existing = categoryRepository.findByUuid(exp.getUuid());
+        CategoryEntity entity;
+        if (existing.isPresent()) {
+          if (!overwrite) {
+            result.setSkippedTotalCount(result.getSkippedTotalCount() + 1);
+            map.put(exp.getUuid(), existing.get());
+            continue;
+          }
+          entity = existing.get();
+          result.setUpdatedCategoryCount(result.getUpdatedCategoryCount() + 1);
+          result.setUpdatedTotalCount(result.getUpdatedTotalCount() + 1);
+        } else {
+          entity = new CategoryEntity();
+          result.setImportedCategoryCount(result.getImportedCategoryCount() + 1);
+          result.setImportedTotalCount(result.getImportedTotalCount() + 1);
+        }
+
+        entity.setUuid(exp.getUuid());
+        entity.setName(exp.getName());
+        entity.setDateAdded(exp.getDateAdded() != null ? exp.getDateAdded() : LocalDateTime.now());
+        entity.setDateModified(exp.getDateModified() != null ? exp.getDateModified() : LocalDateTime.now());
+        map.put(exp.getUuid(), categoryRepository.save(entity));
+      } catch (Exception e) {
+        result.getErrors().add("Failed to import category " + exp.getUuid());
+        result.setFailedTotalCount(result.getFailedTotalCount() + 1);
+        if (failOnError) {
+          throw new RuntimeException(e);
+        }
+      }
     }
     return map;
   }
 
-  private Map<UUID, TagEntity> importTags(List<ExportTag> exportTags) {
+  private Map<UUID, TagEntity> importTags(List<ExportTag> exportTags,
+                                          boolean overwrite,
+                                          boolean failOnError,
+                                          ImportResult result) {
     Map<UUID, TagEntity> map = new HashMap<>();
     if (exportTags == null) {
       return map;
     }
     for (ExportTag exp : exportTags) {
-      TagEntity entity = tagRepository.findByUuid(exp.getUuid()).orElseGet(TagEntity::new);
-      entity.setUuid(exp.getUuid());
-      entity.setName(exp.getName());
-      entity.setDateAdded(exp.getDateAdded() != null ? exp.getDateAdded() : LocalDateTime.now());
-      entity.setDateModified(exp.getDateModified() != null ? exp.getDateModified() : LocalDateTime.now());
-      map.put(exp.getUuid(), tagRepository.save(entity));
+      try {
+        Optional<TagEntity> existing = tagRepository.findByUuid(exp.getUuid());
+        TagEntity entity;
+        if (existing.isPresent()) {
+          if (!overwrite) {
+            result.setSkippedTotalCount(result.getSkippedTotalCount() + 1);
+            map.put(exp.getUuid(), existing.get());
+            continue;
+          }
+          entity = existing.get();
+          result.setUpdatedTagCount(result.getUpdatedTagCount() + 1);
+          result.setUpdatedTotalCount(result.getUpdatedTotalCount() + 1);
+        } else {
+          entity = new TagEntity();
+          result.setImportedTagCount(result.getImportedTagCount() + 1);
+          result.setImportedTotalCount(result.getImportedTotalCount() + 1);
+        }
+
+        entity.setUuid(exp.getUuid());
+        entity.setName(exp.getName());
+        entity.setDateAdded(exp.getDateAdded() != null ? exp.getDateAdded() : LocalDateTime.now());
+        entity.setDateModified(exp.getDateModified() != null ? exp.getDateModified() : LocalDateTime.now());
+        map.put(exp.getUuid(), tagRepository.save(entity));
+      } catch (Exception e) {
+        result.getErrors().add("Failed to import tag " + exp.getUuid());
+        result.setFailedTotalCount(result.getFailedTotalCount() + 1);
+        if (failOnError) {
+          throw new RuntimeException(e);
+        }
+      }
     }
     return map;
   }
@@ -226,46 +364,73 @@ public class ImportService {
                                             Map<UUID, CategoryEntity> categories,
                                             Map<UUID, StorageEntity> storages,
                                             Map<UUID, TagEntity> tags,
-                                            Map<UUID, ImageEntity> images) {
+                                            Map<UUID, ImageEntity> images,
+                                            boolean overwrite,
+                                            boolean failOnError,
+                                            ImportResult result) {
     Map<UUID, ItemEntity> map = new HashMap<>();
     if (exportItems == null) {
       return map;
     }
     for (ExportItem exp : exportItems) {
-      ItemEntity entity = itemRepository.findByUuid(exp.getUuid()).orElseGet(ItemEntity::new);
-      entity.setUuid(exp.getUuid());
-      entity.setName(exp.getName());
-      entity.setDescription(exp.getDescription());
-      entity.setPurchaseDate(exp.getPurchaseDate());
-      entity.setPurchasePrice(exp.getPurchasePrice());
-      entity.setQuantity(exp.getQuantity());
-      entity.setDateAdded(exp.getDateAdded() != null ? exp.getDateAdded() : LocalDateTime.now());
-      entity.setDateModified(exp.getDateModified() != null ? exp.getDateModified() : LocalDateTime.now());
-      if (exp.getCategory() != null) {
-        entity.setCategory(categories.get(exp.getCategory()));
-      }
-      if (exp.getStorage() != null) {
-        entity.setStorage(storages.get(exp.getStorage()));
-      }
-      if (exp.getTags() != null) {
-        Set<TagEntity> tagSet = new HashSet<>();
-        for (UUID uuid : exp.getTags()) {
-          TagEntity t = tags.get(uuid);
-          if (t != null) {
-            tagSet.add(t);
+      try {
+        Optional<ItemEntity> existing = itemRepository.findByUuid(exp.getUuid());
+        ItemEntity entity;
+        if (existing.isPresent()) {
+          if (!overwrite) {
+            result.setSkippedTotalCount(result.getSkippedTotalCount() + 1);
+            map.put(exp.getUuid(), existing.get());
+            continue;
+          }
+          entity = existing.get();
+          result.setUpdatedItemCount(result.getUpdatedItemCount() + 1);
+          result.setUpdatedTotalCount(result.getUpdatedTotalCount() + 1);
+        } else {
+          entity = new ItemEntity();
+          result.setImportedItemCount(result.getImportedItemCount() + 1);
+          result.setImportedTotalCount(result.getImportedTotalCount() + 1);
+        }
+
+        entity.setUuid(exp.getUuid());
+        entity.setName(exp.getName());
+        entity.setDescription(exp.getDescription());
+        entity.setPurchaseDate(exp.getPurchaseDate());
+        entity.setPurchasePrice(exp.getPurchasePrice());
+        entity.setQuantity(exp.getQuantity());
+        entity.setDateAdded(exp.getDateAdded() != null ? exp.getDateAdded() : LocalDateTime.now());
+        entity.setDateModified(exp.getDateModified() != null ? exp.getDateModified() : LocalDateTime.now());
+        if (exp.getCategory() != null) {
+          entity.setCategory(categories.get(exp.getCategory()));
+        }
+        if (exp.getStorage() != null) {
+          entity.setStorage(storages.get(exp.getStorage()));
+        }
+        if (exp.getTags() != null) {
+          Set<TagEntity> tagSet = new HashSet<>();
+          for (UUID uuid : exp.getTags()) {
+            TagEntity t = tags.get(uuid);
+            if (t != null) {
+              tagSet.add(t);
+            }
+          }
+          entity.setTags(tagSet);
+        }
+        ItemEntity saved = itemRepository.save(entity);
+        map.put(exp.getUuid(), saved);
+        if (exp.getImages() != null) {
+          for (UUID imgUuid : exp.getImages()) {
+            ImageEntity img = images.get(imgUuid);
+            if (img != null) {
+              img.setItem(saved);
+              imageRepository.save(img);
+            }
           }
         }
-        entity.setTags(tagSet);
-      }
-      ItemEntity saved = itemRepository.save(entity);
-      map.put(exp.getUuid(), saved);
-      if (exp.getImages() != null) {
-        for (UUID imgUuid : exp.getImages()) {
-          ImageEntity img = images.get(imgUuid);
-          if (img != null) {
-            img.setItem(saved);
-            imageRepository.save(img);
-          }
+      } catch (Exception e) {
+        result.getErrors().add("Failed to import item " + exp.getUuid());
+        result.setFailedTotalCount(result.getFailedTotalCount() + 1);
+        if (failOnError) {
+          throw new RuntimeException(e);
         }
       }
     }

--- a/src/test/java/de/iske/kistogramm/controller/ImportControllerTest.java
+++ b/src/test/java/de/iske/kistogramm/controller/ImportControllerTest.java
@@ -1,0 +1,170 @@
+package de.iske.kistogramm.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.iske.kistogramm.dto.ImportResult;
+import de.iske.kistogramm.dto.export.ExportResult;
+import de.iske.kistogramm.repository.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = "spring.profiles.active=test")
+@AutoConfigureMockMvc
+class ImportControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ItemRepository itemRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private StorageRepository storageRepository;
+    @Autowired
+    private RoomRepository roomRepository;
+    @Autowired
+    private TagRepository tagRepository;
+    @Autowired
+    private ImageRepository imageRepository;
+    @Autowired
+    private CategoryAttributeTemplateRepository categoryAttributeTemplateRepository;
+
+    @Test
+    void shouldExportAndImportArchive() throws Exception {
+        // create dataset similar to export test
+        int wohnzimmerId = TestDataUtil.createRoomWithImage(mockMvc, objectMapper, "Wohnzimmer", "Raum mit Sofa");
+        int schlafzimmerId = TestDataUtil.createRoomWithImage(mockMvc, objectMapper, "Schlafzimmer", "Mit Bett");
+        int barId = TestDataUtil.createRoomWithImage(mockMvc, objectMapper, "Bar", "Raum mit Getränken");
+
+        int regalId = TestDataUtil.createStorageWithImage(mockMvc, objectMapper, "Regal", "Für Bücher", wohnzimmerId);
+        int schrankId = TestDataUtil.createStorageWithImage(mockMvc, objectMapper, "Schrank", "Kleidung", schlafzimmerId);
+        int minibarId = TestDataUtil.createStorageWithImage(mockMvc, objectMapper, "Minibar", "Getränke", barId);
+        int kisteId = TestDataUtil.createStorageWithImage(mockMvc, objectMapper, "Kiste", "Sonstiges", wohnzimmerId);
+
+        int tagWerkzeug = TestDataUtil.createTag(mockMvc, objectMapper, "Werkzeug");
+        int tagKueche = TestDataUtil.createTag(mockMvc, objectMapper, "Küche");
+        int tagGarten = TestDataUtil.createTag(mockMvc, objectMapper, "Garten");
+        int tagDeko = TestDataUtil.createTag(mockMvc, objectMapper, "Deko");
+        int tagSport = TestDataUtil.createTag(mockMvc, objectMapper, "Sport");
+
+        int kategorieBuchId = TestDataUtil.createCategoryWithTemplate(mockMvc, objectMapper, "Buch", List.of("Autor", "Verlag"));
+
+        TestDataUtil.createItemWithDetails(mockMvc, objectMapper, "Roman", "Historisch", regalId, kategorieBuchId,
+                Map.of("Autor", "M. Mustermann"), List.of(tagDeko), 2);
+        TestDataUtil.createItemWithDetails(mockMvc, objectMapper, "Hantelset", "20kg", kisteId, null,
+                Map.of("Farbe", "Schwarz"), List.of(tagSport), 1);
+        TestDataUtil.createItemWithDetails(mockMvc, objectMapper, "Lampe", "LED", regalId, null,
+                Map.of(), List.of(tagDeko), 1);
+        TestDataUtil.createItemWithDetails(mockMvc, objectMapper, "Mixer", "Küchengerät", minibarId, null,
+                Map.of(), List.of(tagKueche), 1);
+        TestDataUtil.createItemWithDetails(mockMvc, objectMapper, "Bettwäsche", "Baumwolle", schrankId, null,
+                Map.of(), List.of(tagGarten), 1);
+        TestDataUtil.createItemWithDetails(mockMvc, objectMapper, "Werkzeugkasten", "Vollausstattung", kisteId, null,
+                Map.of(), List.of(tagWerkzeug), 2);
+        TestDataUtil.createItemWithDetails(mockMvc, objectMapper, "Kochbuch", "Vegetarisch", minibarId, kategorieBuchId,
+                Map.of("Autor", "T. Tofu"), List.of(tagKueche), 1);
+        TestDataUtil.createItemWithDetails(mockMvc, objectMapper, "Poster", "Kunst", regalId, null,
+                Map.of(), List.of(tagDeko), 1);
+        TestDataUtil.createItemWithDetails(mockMvc, objectMapper, "Trinkglas", "Kristall", minibarId, null,
+                Map.of(), List.of(tagDeko), 1);
+        TestDataUtil.createItemWithDetails(mockMvc, objectMapper, "Fernbedienung", "TV", regalId, null,
+                Map.of(), List.of(tagDeko), 1);
+
+        // export archive
+        MvcResult exportRes = mockMvc.perform(get("/api/export"))
+                .andExpect(status().isOk())
+                .andReturn();
+        byte[] zipBytes = exportRes.getResponse().getContentAsByteArray();
+        Map<String, byte[]> extracted = extractZipContents(zipBytes);
+        ExportResult exportResult = objectMapper.readValue(extracted.get("data.json"), ExportResult.class);
+
+        // delete all data
+        imageRepository.deleteAll();
+        itemRepository.deleteAll();
+        storageRepository.deleteAll();
+        roomRepository.deleteAll();
+        categoryAttributeTemplateRepository.deleteAll();
+        categoryRepository.deleteAll();
+        tagRepository.deleteAll();
+
+        MockMultipartFile file = new MockMultipartFile("file", "export.zip", MediaType.APPLICATION_OCTET_STREAM_VALUE, zipBytes);
+        String resp = mockMvc.perform(multipart("/api/import").file(file))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ImportResult importResult = objectMapper.readValue(resp, ImportResult.class);
+        assertThat(importResult.isSuccess()).isTrue();
+        assertThat(itemRepository.count()).isEqualTo(exportResult.getItems().size());
+        assertThat(categoryRepository.count()).isEqualTo(exportResult.getCategories().size());
+        assertThat(tagRepository.count()).isEqualTo(exportResult.getTags().size());
+        assertThat(roomRepository.count()).isEqualTo(exportResult.getRooms().size());
+        assertThat(storageRepository.count()).isEqualTo(exportResult.getStorages().size());
+        assertThat(imageRepository.count()).isEqualTo(exportResult.getImages().size());
+    }
+
+    @Test
+    void shouldOverwriteExistingItemWhenEnabled() throws Exception {
+        int roomId = TestDataUtil.createRoomWithImage(mockMvc, objectMapper, "Raum", "desc");
+        int storageId = TestDataUtil.createStorageWithImage(mockMvc, objectMapper, "Box", "desc", roomId);
+        int tagId = TestDataUtil.createTag(mockMvc, objectMapper, "Tag1");
+        int catId = TestDataUtil.createCategoryWithTemplate(mockMvc, objectMapper, "Buch", List.of("Autor"));
+        int itemId = TestDataUtil.createItemWithDetails(mockMvc, objectMapper, "BuchA", "desc", storageId, catId,
+                Map.of("Autor", "A"), List.of(tagId), 1);
+
+        MvcResult exportRes = mockMvc.perform(get("/api/export"))
+                .andExpect(status().isOk())
+                .andReturn();
+        byte[] zipBytes = exportRes.getResponse().getContentAsByteArray();
+        Map<String, byte[]> extracted = extractZipContents(zipBytes);
+        ExportResult exportResult = objectMapper.readValue(extracted.get("data.json"), ExportResult.class);
+        String originalName = exportResult.getItems().get(0).getName();
+
+        var entity = itemRepository.findById(itemId).orElseThrow();
+        entity.setName("Changed");
+        itemRepository.save(entity);
+
+        MockMultipartFile file = new MockMultipartFile("file", "export.zip", MediaType.APPLICATION_OCTET_STREAM_VALUE, zipBytes);
+        mockMvc.perform(multipart("/api/import").file(file).param("overwrite","false"))
+                .andExpect(status().isOk());
+        assertThat(itemRepository.findById(itemId).orElseThrow().getName()).isEqualTo("Changed");
+
+        mockMvc.perform(multipart("/api/import").file(file).param("overwrite","true"))
+                .andExpect(status().isOk());
+        assertThat(itemRepository.findById(itemId).orElseThrow().getName()).isEqualTo(originalName);
+    }
+
+    private Map<String, byte[]> extractZipContents(byte[] zipBytes) throws IOException {
+        Map<String, byte[]> files = new HashMap<>();
+        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                zis.transferTo(baos);
+                files.put(entry.getName(), baos.toByteArray());
+            }
+        }
+        return files;
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ImportService#importArchive` with overwrite and failOnError handling
- add detailed import logic updating existing entities or skipping based on flags
- create integration tests verifying export+import roundtrip and overwrite behaviour

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6844746e9514832e9e855b46af7522bf