### PR TITLE
Improve English comments

### DIFF
--- a/src/main/java/de/iske/kistogramm/mapper/ItemMapper.java
+++ b/src/main/java/de/iske/kistogramm/mapper/ItemMapper.java
@@ -63,7 +63,8 @@ public interface ItemMapper {
     @Mapping(target = "category", ignore = true)
     @Mapping(target = "storage", ignore = true)
     @Mapping(target = "tags", ignore = true)
-    @Mapping(target = "relatedItems", ignore = true) // Handhabung erfolgt im Service
+    // Related items are processed in the service layer
+    @Mapping(target = "relatedItems", ignore = true)
     @Mapping(target = "images", ignore = true)
     ItemEntity toEntity(Item dto);
 

--- a/src/main/java/de/iske/kistogramm/service/ItemService.java
+++ b/src/main/java/de/iske/kistogramm/service/ItemService.java
@@ -126,7 +126,7 @@ public class ItemService {
         ItemEntity entity = itemRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Item not found: " + id));
 
-        // Update Basisattribute
+        // Update basic attributes
         entity.setName(updatedItem.getName());
         entity.setDescription(updatedItem.getDescription());
         entity.setPurchaseDate(updatedItem.getPurchaseDate());
@@ -134,12 +134,12 @@ public class ItemService {
         entity.setQuantity(updatedItem.getQuantity());
         entity.setDateModified(LocalDateTime.now());
 
-        // Custom Attribute aktualisieren (auch ohne Kategorie erlaubt)
+        // Update custom attributes (allowed even without a category)
         if (updatedItem.getCustomAttributes() != null) {
             entity.setCustomAttributes(updatedItem.getCustomAttributes());
         }
 
-        // Kategorie zuweisen oder ändern
+        // Assign or change the category
         if (updatedItem.getCategoryId() != null) {
             CategoryEntity newCategory = categoryRepository.findById(updatedItem.getCategoryId())
                     .orElseThrow(() -> new IllegalArgumentException("Category not found: " + updatedItem.getCategoryId()));
@@ -149,7 +149,7 @@ public class ItemService {
             if (changed) {
                 entity.setCategory(newCategory);
 
-                // Templates auslesen
+                // Read templates for the new category
                 List<CategoryAttributeTemplateEntity> templates = templateRepository.findByCategoryId(newCategory.getId());
 
                 Map<String, String> currentAttrs = new HashMap<>(entity.getCustomAttributes());
@@ -160,11 +160,11 @@ public class ItemService {
                 entity.setCustomAttributes(currentAttrs);
             }
         } else {
-            // Kategorie entfernen (falls gewünscht) – optional, je nach Bedarf
+            // Remove category if desired
             entity.setCategory(null);
         }
 
-        // Storage-Zuweisung aktualisieren (auch null erlaubt)
+        // Update storage assignment (null allowed)
         if (updatedItem.getStorageId() != null) {
             StorageEntity storage = storageRepository.findById(updatedItem.getStorageId())
                     .orElseThrow(() -> new IllegalArgumentException("Storage not found: " + updatedItem.getStorageId()));
@@ -173,7 +173,7 @@ public class ItemService {
             entity.setStorage(null);
         }
 
-        // Tags aktualisieren
+        // Update tags
         if (updatedItem.getTagIds() != null) {
             Set<TagEntity> newTags = new HashSet<>(tagRepository.findAllById(updatedItem.getTagIds()));
             entity.setTags(newTags);
@@ -269,17 +269,17 @@ public class ItemService {
         ImageEntity imageToRemove = imageRepository.findById(imageId)
                 .orElseThrow(() -> new IllegalArgumentException("Image not found: " + imageId));
 
-        // Prüfen, ob das Bild zu diesem Item gehört
+        // Check whether the image belongs to this item
         if (!item.getImages().contains(imageToRemove)) {
             throw new IllegalArgumentException("Image does not belong to this item");
         }
 
-        // Entfernen aus der Beziehung
+        // Remove from the item-image relationship
         item.getImages().remove(imageToRemove);
         item.setDateModified(LocalDateTime.now());
         itemRepository.save(item);
 
-        // Bild selbst löschen
+        // Delete the image entity
         imageRepository.delete(imageToRemove);
     }
 
@@ -302,11 +302,11 @@ public class ItemService {
         ItemEntity item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new IllegalArgumentException("Item not found: " + itemId));
 
-        // Alle Bilder des Items löschen
+        // Delete all images of the item
         for (ImageEntity image : item.getImages()) {
             imageRepository.delete(image);
         }
-        // Bilder aus der Item-Referenz entfernen
+        // Remove image references from the item
         item.getImages().clear();
         item.setDateModified(LocalDateTime.now());
         itemRepository.save(item);

--- a/src/main/java/de/iske/kistogramm/service/StorageService.java
+++ b/src/main/java/de/iske/kistogramm/service/StorageService.java
@@ -125,7 +125,7 @@ public class StorageService {
             entity.setParentStorage(null);
         }
 
-        // Optional: Tags neu zuweisen
+        // Optionally reassign tags
         if (updatedStorage.getTagIds() != null) {
             List<TagEntity> tags = tagRepository.findAllById(updatedStorage.getTagIds());
             entity.setTags(new HashSet<>(tags));


### PR DESCRIPTION
## Summary
- rewrite German inline comments in the service layer
- clarify mapping comment in `ItemMapper`

## Testing
- `mvn test` *(fails: release version 24 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_684834bf8f70832e8c52e98a2aedfb25