### PR TITLE
Fix test cleanup

### DIFF
--- a/src/test/java/de/iske/kistogramm/config/DefaultCategoryInitializerTest.java
+++ b/src/test/java/de/iske/kistogramm/config/DefaultCategoryInitializerTest.java
@@ -7,6 +7,7 @@ import de.iske.kistogramm.repository.CategoryRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +15,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(properties = "spring.profiles.active=test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 class DefaultCategoryInitializerTest {
 
     @Autowired
@@ -21,7 +23,6 @@ class DefaultCategoryInitializerTest {
 
     @Autowired
     private CategoryAttributeTemplateRepository categoryAttributeTemplateRepository;
-
 
     @Test
     void shouldCreateDefaultCategoriesWithAttributes() {

--- a/src/test/java/de/iske/kistogramm/controller/AbstractControllerTest.java
+++ b/src/test/java/de/iske/kistogramm/controller/AbstractControllerTest.java
@@ -27,16 +27,7 @@ public abstract class AbstractControllerTest {
 
     @BeforeEach
     void cleanDatabase() {
-        // unlink images to avoid foreign key constraints
-        itemRepository.findAll().forEach(item -> {
-            item.setImages(null);
-            item.setReceipts(null);
-            itemRepository.save(item);
-        });
-        storageRepository.findAll().forEach(storage -> {
-            storage.setImages(null);
-            storageRepository.save(storage);
-        });
+        // unlink room images to avoid foreign key constraints
         roomRepository.findAll().forEach(room -> {
             room.setImage(null);
             roomRepository.save(room);

--- a/src/test/java/de/iske/kistogramm/controller/AbstractControllerTest.java
+++ b/src/test/java/de/iske/kistogramm/controller/AbstractControllerTest.java
@@ -5,9 +5,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 
 @SpringBootTest(properties = "spring.profiles.active=test")
 @AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public abstract class AbstractControllerTest {
 
     @Autowired

--- a/src/test/java/de/iske/kistogramm/service/StorageServiceTest.java
+++ b/src/test/java/de/iske/kistogramm/service/StorageServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -16,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(properties = "spring.profiles.active=test")
 @Transactional
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 class StorageServiceTest {
 
     @Autowired

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+# ClassOrderer$OrderAnnotation sorts classes based on their @Order annotation
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$Random


### PR DESCRIPTION
## Summary
- avoid lazy init errors during controller tests by simplifying cleanup logic

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_684c0285cb88832eba4583ad9a104aa8