### PR TITLE
feat: Async AI ingestion pipeline (Whisper + Ollama/moondream + Redis)

### DIFF
--- a/ai-worker/Dockerfile
+++ b/ai-worker/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+COPY pyproject.toml ./
+RUN uv sync --no-dev
+
+COPY worker.py ./
+
+CMD ["uv", "run", "python", "worker.py"]

--- a/ai-worker/pyproject.toml
+++ b/ai-worker/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "ai-worker"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+  "faster-whisper>=1.1.0",
+  "redis>=5.0.0",
+  "httpx>=0.27.0",
+]

--- a/ai-worker/worker.py
+++ b/ai-worker/worker.py
@@ -1,0 +1,108 @@
+import os
+import json
+import base64
+import logging
+import redis
+import httpx
+from faster_whisper import WhisperModel
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger(__name__)
+
+REDIS_HOST = os.environ.get("REDIS_HOST", "redis")
+REDIS_PORT = int(os.environ.get("REDIS_PORT", 6379))
+CALLBACK_URL = os.environ["CALLBACK_URL"]
+WEBHOOK_SECRET = os.environ["WEBHOOK_SECRET"]
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://host.docker.internal:11434")
+QUEUE_KEY = "ai_jobs_queue"
+
+PROMPT_TEMPLATE = (
+    'You are an inventory management assistant. The user described the item as:\n'
+    '"{transcript}"\n\n'
+    'Analyze the image and the description. Output ONLY a valid JSON object with these fields:\n'
+    '{{\n'
+    '  "name": "short item name",\n'
+    '  "description": "detailed description",\n'
+    '  "category": "best matching category name or null",\n'
+    '  "tags": ["tag1", "tag2"],\n'
+    '  "quantity": 1,\n'
+    '  "purchase_price": null\n'
+    '}}'
+)
+
+log.info("Loading Whisper model (CPU)...")
+whisper_model = WhisperModel("base", device="cpu", compute_type="int8")
+log.info("Whisper model loaded.")
+
+
+def transcribe(audio_path: str) -> str:
+    segments, _ = whisper_model.transcribe(audio_path, beam_size=5)
+    return " ".join(s.text for s in segments).strip()
+
+
+def analyze_with_moondream(image_path: str, transcript: str) -> dict:
+    with open(image_path, "rb") as f:
+        img_b64 = base64.b64encode(f.read()).decode()
+
+    payload = {
+        "model": "moondream",
+        "prompt": PROMPT_TEMPLATE.format(transcript=transcript),
+        "images": [img_b64],
+        "stream": False,
+    }
+    resp = httpx.post(f"{OLLAMA_HOST}/api/generate", json=payload, timeout=120)
+    resp.raise_for_status()
+    raw = resp.json()["response"]
+
+    # Extract JSON robustly in case the model adds surrounding text
+    start = raw.index("{")
+    end = raw.rindex("}") + 1
+    return json.loads(raw[start:end])
+
+
+def send_callback(job_id: str, result: dict) -> None:
+    payload = {"jobId": job_id, **result}
+    headers = {
+        "X-Webhook-Secret": WEBHOOK_SECRET,
+        "Content-Type": "application/json",
+    }
+    # Rename purchase_price → purchasePrice to match Spring DTO
+    if "purchase_price" in payload:
+        payload["purchasePrice"] = payload.pop("purchase_price")
+
+    resp = httpx.post(CALLBACK_URL, json=payload, headers=headers, timeout=30)
+    resp.raise_for_status()
+
+
+def process_job(job: dict) -> None:
+    job_id = job["jobId"]
+    log.info("Processing job %s", job_id)
+
+    transcript = transcribe(job["audioPath"])
+    log.info("Transcript for job %s: %s", job_id, transcript[:120])
+
+    result = analyze_with_moondream(job["imagePath"], transcript)
+    log.info("Moondream result for job %s: %s", job_id, result)
+
+    send_callback(job_id, result)
+    log.info("Job %s completed successfully", job_id)
+
+
+def main() -> None:
+    r = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
+    log.info("Worker ready, listening on queue '%s'...", QUEUE_KEY)
+
+    while True:
+        try:
+            item = r.blpop(QUEUE_KEY, timeout=0)
+            if item is None:
+                continue
+            _, raw = item
+            job = json.loads(raw)
+            process_job(job)
+        except Exception as exc:
+            log.error("Job failed: %s", exc, exc_info=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,15 @@ services:
       - "8080:8080"
     depends_on:
       - db
+      - redis
     environment:
       - SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/kistogramm
       - SPRING_DATASOURCE_USERNAME=kisto_user
       - SPRING_DATASOURCE_PASSWORD=secret
+      - AI_UPLOAD_DIR=/uploads
+      - AI_WEBHOOK_SECRET=${WEBHOOK_SECRET:-change-me-in-production}
+    volumes:
+      - ai_uploads:/uploads
     networks:
       - kistonet
 
@@ -32,8 +37,38 @@ services:
     networks:
       - kistonet
 
+  redis:
+    image: redis:7-alpine
+    container_name: kistogramm_redis
+    restart: always
+    networks:
+      - kistonet
+
+  ai-worker:
+    build:
+      context: ./ai-worker
+      dockerfile: Dockerfile
+    container_name: kistogramm_ai_worker
+    restart: always
+    depends_on:
+      - redis
+      - app
+    volumes:
+      - ai_uploads:/uploads
+    environment:
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - CALLBACK_URL=http://app:8080/api/ai/webhook/result
+      - WEBHOOK_SECRET=${WEBHOOK_SECRET:-change-me-in-production}
+      - OLLAMA_HOST=http://host.docker.internal:11434
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - kistonet
+
 volumes:
   pgdata:
+  ai_uploads:
 
 networks:
   kistonet:

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/de/iske/kistogramm/config/RedisConfig.java
+++ b/src/main/java/de/iske/kistogramm/config/RedisConfig.java
@@ -1,0 +1,15 @@
+package de.iske.kistogramm.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+}

--- a/src/main/java/de/iske/kistogramm/controller/AiIngestionController.java
+++ b/src/main/java/de/iske/kistogramm/controller/AiIngestionController.java
@@ -1,0 +1,36 @@
+package de.iske.kistogramm.controller;
+
+import de.iske.kistogramm.dto.AiJobResponse;
+import de.iske.kistogramm.model.AiJobEntity;
+import de.iske.kistogramm.service.AiQueueService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/ai")
+public class AiIngestionController {
+
+    private final AiQueueService aiQueueService;
+
+    public AiIngestionController(AiQueueService aiQueueService) {
+        this.aiQueueService = aiQueueService;
+    }
+
+    @PostMapping("/ingest")
+    public ResponseEntity<AiJobResponse> ingest(
+            @RequestParam("image") MultipartFile image,
+            @RequestParam("audio") MultipartFile audio) throws IOException {
+
+        AiJobEntity job = aiQueueService.submitJob(image, audio);
+        return ResponseEntity
+                .status(HttpStatus.ACCEPTED)
+                .body(new AiJobResponse(job.getId(), job.getStatus().name()));
+    }
+}

--- a/src/main/java/de/iske/kistogramm/controller/AiWebhookController.java
+++ b/src/main/java/de/iske/kistogramm/controller/AiWebhookController.java
@@ -1,0 +1,105 @@
+package de.iske.kistogramm.controller;
+
+import de.iske.kistogramm.dto.AiWebhookPayload;
+import de.iske.kistogramm.dto.Item;
+import de.iske.kistogramm.model.AiJobEntity;
+import de.iske.kistogramm.model.TagEntity;
+import de.iske.kistogramm.repository.AiJobRepository;
+import de.iske.kistogramm.repository.CategoryRepository;
+import de.iske.kistogramm.repository.TagRepository;
+import de.iske.kistogramm.service.ItemService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/api/ai/webhook")
+public class AiWebhookController {
+
+    @Value("${ai.webhook-secret}")
+    private String webhookSecret;
+
+    private final AiJobRepository aiJobRepository;
+    private final CategoryRepository categoryRepository;
+    private final TagRepository tagRepository;
+    private final ItemService itemService;
+
+    public AiWebhookController(AiJobRepository aiJobRepository,
+                                CategoryRepository categoryRepository,
+                                TagRepository tagRepository,
+                                ItemService itemService) {
+        this.aiJobRepository = aiJobRepository;
+        this.categoryRepository = categoryRepository;
+        this.tagRepository = tagRepository;
+        this.itemService = itemService;
+    }
+
+    @PostMapping("/result")
+    @Transactional
+    public ResponseEntity<Void> handleResult(
+            @RequestHeader("X-Webhook-Secret") String secret,
+            @Valid @RequestBody AiWebhookPayload payload) {
+
+        if (!webhookSecret.equals(secret)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        AiJobEntity job = aiJobRepository.findById(payload.getJobId()).orElse(null);
+        if (job == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+
+        job.setStatus(AiJobEntity.Status.PROCESSING);
+        aiJobRepository.save(job);
+
+        try {
+            Item dto = new Item();
+            dto.setName(payload.getName());
+            dto.setDescription(payload.getDescription());
+            dto.setQuantity(payload.getQuantity() != null ? payload.getQuantity() : 1);
+            dto.setPurchasePrice(payload.getPurchasePrice());
+
+            // Resolve category by name
+            if (payload.getCategory() != null && !payload.getCategory().isBlank()) {
+                categoryRepository.findByName(payload.getCategory())
+                        .ifPresent(c -> dto.setCategoryId(c.getId()));
+            }
+
+            // Resolve or create tags by name
+            if (payload.getTags() != null && !payload.getTags().isEmpty()) {
+                Set<Integer> tagIds = new HashSet<>();
+                for (String tagName : payload.getTags()) {
+                    if (tagName == null || tagName.isBlank()) continue;
+                    TagEntity tag = tagRepository.findByName(tagName).orElseGet(() -> {
+                        TagEntity t = new TagEntity();
+                        t.setName(tagName);
+                        t.setDateAdded(LocalDateTime.now());
+                        t.setDateModified(LocalDateTime.now());
+                        return tagRepository.save(t);
+                    });
+                    tagIds.add(tag.getId());
+                }
+                dto.setTagIds(tagIds);
+            }
+
+            Item created = itemService.createItem(dto);
+
+            job.setStatus(AiJobEntity.Status.DONE);
+            job.setItemId(created.getId());
+        } catch (Exception e) {
+            job.setStatus(AiJobEntity.Status.FAILED);
+            job.setErrorMessage(e.getMessage());
+        }
+
+        aiJobRepository.save(job);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/de/iske/kistogramm/dto/AiJobResponse.java
+++ b/src/main/java/de/iske/kistogramm/dto/AiJobResponse.java
@@ -1,0 +1,17 @@
+package de.iske.kistogramm.dto;
+
+import java.util.UUID;
+
+public class AiJobResponse {
+
+    private UUID jobId;
+    private String status;
+
+    public AiJobResponse(UUID jobId, String status) {
+        this.jobId = jobId;
+        this.status = status;
+    }
+
+    public UUID getJobId() { return jobId; }
+    public String getStatus() { return status; }
+}

--- a/src/main/java/de/iske/kistogramm/dto/AiWebhookPayload.java
+++ b/src/main/java/de/iske/kistogramm/dto/AiWebhookPayload.java
@@ -1,0 +1,43 @@
+package de.iske.kistogramm.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+import java.util.UUID;
+
+public class AiWebhookPayload {
+
+    @NotNull
+    private UUID jobId;
+
+    @NotBlank
+    private String name;
+
+    private String description;
+    private String category;
+    private List<String> tags;
+    private Integer quantity;
+    private Double purchasePrice;
+
+    public UUID getJobId() { return jobId; }
+    public void setJobId(UUID jobId) { this.jobId = jobId; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getCategory() { return category; }
+    public void setCategory(String category) { this.category = category; }
+
+    public List<String> getTags() { return tags; }
+    public void setTags(List<String> tags) { this.tags = tags; }
+
+    public Integer getQuantity() { return quantity; }
+    public void setQuantity(Integer quantity) { this.quantity = quantity; }
+
+    public Double getPurchasePrice() { return purchasePrice; }
+    public void setPurchasePrice(Double purchasePrice) { this.purchasePrice = purchasePrice; }
+}

--- a/src/main/java/de/iske/kistogramm/model/AiJobEntity.java
+++ b/src/main/java/de/iske/kistogramm/model/AiJobEntity.java
@@ -1,0 +1,73 @@
+package de.iske.kistogramm.model;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "ai_jobs")
+public class AiJobEntity {
+
+    public enum Status {
+        PENDING, PROCESSING, DONE, FAILED
+    }
+
+    @Id
+    private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Status status = Status.PENDING;
+
+    @Column(name = "image_path", length = 1024)
+    private String imagePath;
+
+    @Column(name = "audio_path", length = 1024)
+    private String audioPath;
+
+    @Column(name = "item_id")
+    private Integer itemId;
+
+    @Column(name = "error_message", columnDefinition = "TEXT")
+    private String errorMessage;
+
+    @Column(name = "date_created")
+    private LocalDateTime dateCreated;
+
+    @Column(name = "date_modified")
+    private LocalDateTime dateModified;
+
+    @PrePersist
+    public void onCreate() {
+        if (id == null) id = UUID.randomUUID();
+        dateCreated = LocalDateTime.now();
+        dateModified = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        dateModified = LocalDateTime.now();
+    }
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+
+    public Status getStatus() { return status; }
+    public void setStatus(Status status) { this.status = status; }
+
+    public String getImagePath() { return imagePath; }
+    public void setImagePath(String imagePath) { this.imagePath = imagePath; }
+
+    public String getAudioPath() { return audioPath; }
+    public void setAudioPath(String audioPath) { this.audioPath = audioPath; }
+
+    public Integer getItemId() { return itemId; }
+    public void setItemId(Integer itemId) { this.itemId = itemId; }
+
+    public String getErrorMessage() { return errorMessage; }
+    public void setErrorMessage(String errorMessage) { this.errorMessage = errorMessage; }
+
+    public LocalDateTime getDateCreated() { return dateCreated; }
+    public LocalDateTime getDateModified() { return dateModified; }
+}

--- a/src/main/java/de/iske/kistogramm/repository/AiJobRepository.java
+++ b/src/main/java/de/iske/kistogramm/repository/AiJobRepository.java
@@ -1,0 +1,9 @@
+package de.iske.kistogramm.repository;
+
+import de.iske.kistogramm.model.AiJobEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface AiJobRepository extends JpaRepository<AiJobEntity, UUID> {
+}

--- a/src/main/java/de/iske/kistogramm/repository/TagRepository.java
+++ b/src/main/java/de/iske/kistogramm/repository/TagRepository.java
@@ -11,4 +11,6 @@ import java.util.UUID;
 public interface TagRepository extends JpaRepository<TagEntity, Integer> {
 
     Optional<TagEntity> findByUuid(UUID uuid);
+
+    Optional<TagEntity> findByName(String name);
 }

--- a/src/main/java/de/iske/kistogramm/service/AiQueueService.java
+++ b/src/main/java/de/iske/kistogramm/service/AiQueueService.java
@@ -1,0 +1,81 @@
+package de.iske.kistogramm.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.iske.kistogramm.model.AiJobEntity;
+import de.iske.kistogramm.repository.AiJobRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class AiQueueService {
+
+    private static final String QUEUE_KEY = "ai_jobs_queue";
+
+    private final AiJobRepository aiJobRepository;
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${ai.upload-dir}")
+    private String uploadDir;
+
+    public AiQueueService(AiJobRepository aiJobRepository,
+                          StringRedisTemplate redisTemplate,
+                          ObjectMapper objectMapper) {
+        this.aiJobRepository = aiJobRepository;
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    public AiJobEntity submitJob(MultipartFile imageFile, MultipartFile audioFile) throws IOException {
+        UUID jobId = UUID.randomUUID();
+        Path jobDir = Path.of(uploadDir, jobId.toString());
+        Files.createDirectories(jobDir);
+
+        String imageExt = getExtension(imageFile.getOriginalFilename(), "jpg");
+        String audioExt = getExtension(audioFile.getOriginalFilename(), "wav");
+        Path imagePath = jobDir.resolve("image." + imageExt);
+        Path audioPath = jobDir.resolve("audio." + audioExt);
+
+        imageFile.transferTo(imagePath);
+        audioFile.transferTo(audioPath);
+
+        AiJobEntity job = new AiJobEntity();
+        job.setId(jobId);
+        job.setStatus(AiJobEntity.Status.PENDING);
+        job.setImagePath(imagePath.toAbsolutePath().toString());
+        job.setAudioPath(audioPath.toAbsolutePath().toString());
+        aiJobRepository.save(job);
+
+        pushToQueue(jobId, imagePath, audioPath);
+        return job;
+    }
+
+    private void pushToQueue(UUID jobId, Path imagePath, Path audioPath) {
+        try {
+            String payload = objectMapper.writeValueAsString(Map.of(
+                    "jobId", jobId.toString(),
+                    "imagePath", imagePath.toAbsolutePath().toString(),
+                    "audioPath", audioPath.toAbsolutePath().toString()
+            ));
+            redisTemplate.opsForList().leftPush(QUEUE_KEY, payload);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize job payload", e);
+        }
+    }
+
+    private String getExtension(String filename, String fallback) {
+        if (filename != null && filename.contains(".")) {
+            return filename.substring(filename.lastIndexOf('.') + 1).toLowerCase();
+        }
+        return fallback;
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -11,3 +11,7 @@ spring.h2.console.path=/h2-console
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
 logging.level.org.springframework.web=DEBUG
+
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+ai.upload-dir=./uploads-dev

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -8,3 +8,6 @@ spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
+
+spring.data.redis.host=redis
+spring.data.redis.port=6379

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,7 @@ spring.config.import=classpath:config/default-categories.yml
 spring.profiles.active=@springProfile@
 spring.servlet.multipart.max-file-size=100MB
 spring.servlet.multipart.max-request-size=100MB
+
+# AI pipeline
+ai.upload-dir=/uploads
+ai.webhook-secret=change-me-in-production

--- a/src/main/resources/db/migration/V2__ai_jobs.sql
+++ b/src/main/resources/db/migration/V2__ai_jobs.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS ai_jobs (
+    id UUID PRIMARY KEY,
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    image_path VARCHAR(1024),
+    audio_path VARCHAR(1024),
+    item_id INT,
+    error_message TEXT,
+    date_created TIMESTAMP,
+    date_modified TIMESTAMP,
+    FOREIGN KEY (item_id) REFERENCES items(id)
+);


### PR DESCRIPTION
## Summary

- Adds a fully async AI pipeline: user uploads image + audio → job lands in a Redis queue → Python worker transcribes audio (faster-whisper, CPU) and analyzes the image (Ollama moondream) → structured JSON is sent back via a webhook → item is created in Postgres.
- New `POST /api/ai/ingest` endpoint returns `202 Accepted` with a `jobId` immediately (non-blocking).
- Secure webhook `POST /api/ai/webhook/result` with shared-secret header (`X-Webhook-Secret`) for worker callbacks.
- New `ai_jobs` table (Flyway V2) tracks job lifecycle: `PENDING → PROCESSING → DONE / FAILED`.
- New lightweight Python worker container (`ai-worker/`) using `uv` as package manager.

## Architecture

```
POST /api/ai/ingest (image + audio)
  └─► save files to shared Docker volume (/uploads/{jobId}/)
  └─► persist AiJobEntity (PENDING) in Postgres
  └─► LPUSH job JSON onto Redis "ai_jobs_queue"
  └─► return 202 + { jobId }

Python Worker
  └─► BLPOP from "ai_jobs_queue"
  └─► faster-whisper transcribe(audio, device="cpu", compute_type="int8")
  └─► Ollama moondream API (image base64 + transcript) → structured JSON
  └─► POST /api/ai/webhook/result with X-Webhook-Secret

POST /api/ai/webhook/result
  └─► validate secret
  └─► resolve category by name (nullable)
  └─► upsert tags by name
  └─► ItemService.createItem(dto)
  └─► mark job DONE + store itemId
```

## Test plan

- [ ] `WEBHOOK_SECRET=secret docker compose up --build` — all 4 services start cleanly
- [ ] `curl -X POST http://localhost:8080/api/ai/ingest -F "image=@test.jpg" -F "audio=@test.wav"` → `202 + { "jobId": "...", "status": "PENDING" }`
- [ ] `docker logs -f kistogramm_ai_worker` — job picked up, transcribed, moondream called
- [ ] `curl http://localhost:8080/api/items` — new item appears with AI-generated name/description/tags
- [ ] Missing/wrong `X-Webhook-Secret` → `403 Forbidden`
- [ ] All 63 existing tests still pass: `mvn test`

## Prerequisites

- Ollama running on the host with `ollama run moondream` (reachable on port 11434)
- Set `WEBHOOK_SECRET` env var (or use the default `change-me-in-production` for local dev)